### PR TITLE
Add Language support for AWS Locations service

### DIFF
--- a/lib/geocoder/lookups/amazon_location_service.rb
+++ b/lib/geocoder/lookups/amazon_location_service.rb
@@ -10,6 +10,9 @@ module Geocoder::Lookup
       # Aws::ParamValidator raises ArgumentError on missing required keys
       params.merge!(index_name: configuration[:index_name])
 
+      # Inherit language from configuration
+      params.merge!(language: configuration[:language])
+
       # Aws::ParamValidator raises ArgumentError on unexpected keys
       params.delete(:lookup) 
       


### PR DESCRIPTION
This change will use `language` option from the config. Example: 
`language: :en`
Before this PR:
```
  label = "ทางหลวงชนบทภก. 4018 ตำบลเชิงทะเล อำเภอถลาง จังหวัดภูเก็ต 83110",
  municipality = "ตำบลเชิงทะเล",
  postal_code = "83110",
  region = "จังหวัดภูเก็ต",
  sub_region = "อำเภอถลาง",
```

after:
```
  label = "Phuket 4018 Rural Rd, Choeng Thale, Thalang, Phuket 83110, THA",
  municipality = "Choeng Thale",
  postal_code = "83110",
  region = "Phuket",
  sub_region = "Thalang",
```